### PR TITLE
Prevent interactive questions during apt-get dist-upgrade

### DIFF
--- a/autobootstrap.sh
+++ b/autobootstrap.sh
@@ -92,6 +92,9 @@ function setupapt {
 
   echo -n "* Executing apt-get dist-upgrade"
   DEBIAN_FRONTEND=noninteractive
+  unset UCF_FORCE_CONFFOLD
+  export UCF_FORCE_CONFFNEW=YES
+  ucf --purge /boot/grub/menu.lst
   apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy dist-upgrade
   echo " - Done"
   /usr/bin/logger -t autobootstrap "ran apt-get dist-upgrade"


### PR DESCRIPTION
Although a number of options are already configured to set non-interactive APT upgrade, the bootstrap script still hangs with a pending question. Based on the following answer, I updated the bootstrap script.

Source: https://askubuntu.com/a/262445

This was still found as the last content in `/var/log/cloud-init.log` of my failing EC2 instance:
```
A new version of /boot/grub/menu.lst is available, but the version installed
currently has been locally modified.

  1. install the package maintainer's version
  2. keep the local version currently installed
  3. show the differences between the versions
  4. show a side-by-side difference between the versions
  5. show a 3-way difference between available versions
  6. do a 3-way merge between available versions (experimental)
  7. start a new shell to examine the situation

What would you like to do about menu.lst?
```
